### PR TITLE
ToJson implementation for Timespec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::ops::{Add, Sub};
 use std::io;
+#[cfg(feature = "rustc-serialize")]
+use rustc_serialize::json::{self, Json, ToJson};
 
 pub use duration::Duration;
 
@@ -205,6 +207,13 @@ impl Sub<Timespec> for Timespec {
         let sec = self.sec - other.sec;
         let nsec = self.nsec - other.nsec;
         Duration::seconds(sec) + Duration::nanoseconds(nsec as i64)
+    }
+}
+
+#[cfg(feature = "rustc-serialize")]
+impl ToJson for Timespec {
+    fn to_json(&self) -> Json {
+        Json::String(json::encode(&self).unwrap())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use std::fmt;
 use std::ops::{Add, Sub};
 use std::io;
 #[cfg(feature = "rustc-serialize")]
-use rustc_serialize::json::{self, Json, ToJson};
+use rustc_serialize::json::{Json, ToJson};
 
 pub use duration::Duration;
 
@@ -213,7 +213,10 @@ impl Sub<Timespec> for Timespec {
 #[cfg(feature = "rustc-serialize")]
 impl ToJson for Timespec {
     fn to_json(&self) -> Json {
-        Json::String(json::encode(&self).unwrap())
+        let mut container = std::collections::BTreeMap::new();
+        container.insert("sec".to_string(), self.sec.to_json());
+        container.insert("nsec".to_string(), self.nsec.to_json());
+        Json::Object(container)
     }
 }
 


### PR DESCRIPTION
Why RustcEncodable and RustcEncodable are derived for Timespec and there is no ToJson trivial implementation?
I've messed up there #105 so I've made a new request.