### PR TITLE
Not pull in win dependencies when not on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ Utilities for working with time-related functions in Rust.
 
 [dependencies]
 libc = "0.2.1"
+rustc-serialize = { version = "0.3", optional = true }
+
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2.0"
 kernel32-sys = "0.2.0"
-rustc-serialize = { version = "0.3", optional = true }
 
 [dev-dependencies]
 log = "0.3"


### PR DESCRIPTION
This should avoid a bunch of unnecessary compiling (even download?) when not used on windows.