### PR TITLE
Workaround lack of tm_gmtoff on Solaris.

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -209,6 +209,12 @@ mod inner {
     #[cfg(all(not(target_os = "macos"), not(target_os = "ios")))]
     pub use self::unix::*;
 
+    #[cfg(target_os = "solaris")]
+    extern {
+        static timezone: time_t;
+        static altzone: time_t;
+    }
+
     fn rust_tm_to_tm(rust_tm: &Tm, tm: &mut libc::tm) {
         tm.tm_sec = rust_tm.tm_sec;
         tm.tm_min = rust_tm.tm_min;
@@ -277,7 +283,22 @@ mod inner {
             if libc::localtime_r(&sec, &mut out).is_null() {
                 panic!("localtime_r failed: {}", io::Error::last_os_error());
             }
-            tm_to_rust_tm(&out, out.tm_gmtoff as i32, tm);
+            #[cfg(target_os = "solaris")]
+            let gmtoff = {
+                ::tzset();
+                // < 0 means we don't know; assume we're not in DST.
+                if out.tm_isdst == 0 {
+                    // timezone is seconds west of UTC, tm_gmtoff is seconds east
+                    -timezone
+                } else if out.tm_isdst > 0 {
+                    -altzone
+                } else {
+                    -timezone
+                }
+            };
+            #[cfg(not(target_os = "solaris"))]
+            let gmtoff = out.tm_gmtoff;
+            tm_to_rust_tm(&out, gmtoff as i32, tm);
         }
     }
 


### PR DESCRIPTION
The crate doesn't compile at all on Solaris due to a missing tm_gmtoff.  Until we get that implemented natively, we should have a workaround.  I'm not sure how to make it dynamic based on the presence or absence of the symbol in the struct, but this is at least a start.  It compiles and passes the testsuite.

@binarycrusader