### PR TITLE
Make use of timegm workaround in utc_tm_to_time

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -305,7 +305,7 @@ mod inner {
     pub fn utc_tm_to_time(rust_tm: &Tm) -> i64 {
         #[cfg(all(target_os = "android", target_pointer_width = "32"))]
         use libc::timegm64 as timegm;
-        #[cfg(not(all(target_os = "android", target_pointer_width = "32")))]
+        #[cfg(not(any(all(target_os = "android", target_pointer_width = "32"), target_os = "nacl", target_os = "solaris")))]
         use libc::timegm;
 
         let mut tm = unsafe { mem::zeroed() };


### PR DESCRIPTION
This commit is in addition to #155. With this change applied, I can finally build on Solaris 10.
I think, the nacl part of the change has to be made to also make use of timegm workaround for nacl.