### PR TITLE
Fix pulldown documentation rendering warnings

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -193,7 +193,7 @@ impl Duration {
     }
 
     /// Returns the total number of whole microseconds in the duration,
-    /// or `None` on overflow (exceeding 2^63 microseconds in either direction).
+    /// or `None` on overflow (exceeding 2<sup>63</sup> microseconds in either direction).
     pub fn num_microseconds(&self) -> Option<i64> {
         let secs_part = try_opt!(self.num_seconds().checked_mul(MICROS_PER_SEC));
         let nanos_part = self.nanos_mod_sec() / NANOS_PER_MICRO;
@@ -201,7 +201,7 @@ impl Duration {
     }
 
     /// Returns the total number of whole nanoseconds in the duration,
-    /// or `None` on overflow (exceeding 2^63 nanoseconds in either direction).
+    /// or `None` on overflow (exceeding 2<sup>63</sup> nanoseconds in either direction).
     pub fn num_nanoseconds(&self) -> Option<i64> {
         let secs_part = try_opt!(self.num_seconds().checked_mul(NANOS_PER_SEC as i64));
         let nanos_part = self.nanos_mod_sec();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@
 //! extern crate time;
 //! ```
 //!
-//! This crate uses the same syntax for format strings as the [strftime()]
-//! (http://man7.org/linux/man-pages/man3/strftime.3.html) function from the C
-//! standard library.
+//! This crate uses the same syntax for format strings as the
+//! [`strftime()`](http://man7.org/linux/man-pages/man3/strftime.3.html)
+//! function from the C standard library.
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
@@ -332,7 +332,7 @@ pub struct Tm {
     /// Identifies the time zone that was used to compute this broken-down time
     /// value, including any adjustment for Daylight Saving Time. This is the
     /// number of seconds east of UTC. For example, for U.S. Pacific Daylight
-    /// Time, the value is -7*60*60 = -25200.
+    /// Time, the value is `-7*60*60 = -25200`.
     pub tm_utcoff: i32,
 
     /// Nanoseconds after the second - [0, 10<sup>9</sup> - 1]


### PR DESCRIPTION
Fixes these warnings:

```
 Documenting time v0.1.38 (file:///home/niklas/Projekte/rust-time)
WARNING: documentation for this crate may be rendered differently using the new Pulldown renderer.
    See https://github.com/rust-lang/rust/issues/44229 for details.
WARNING: rendering difference in `Simple time handling.`
   --> src/lib.rs:11:0
    /html[0]/body[1]/p[6] Text differs:
        expected: `... [strftime()]`
        found:    `...`
WARNING: rendering difference in `Simple time handling.`
   --> src/lib.rs:11:0
    /html[0]/body[1]/p[6] Unexpected element `a`: found: `<a href="http://man7.org/linux/man-pages/man3/strf ... html">strftime()</a>`
WARNING: rendering difference in `Simple time handling.`
   --> src/lib.rs:11:0
    /html[0]/body[1]/p[6] One element is missing: expected: ` function from the C`
WARNING: rendering difference in `Identifies the time zone that was used to compute  ... his broken-down time`
   --> src/lib.rs:336:4
    /html[0]/body[1]/p[0] Text differs:
        expected: `...`
        found:    `...*60*60 = -25200.`
WARNING: rendering difference in `Identifies the time zone that was used to compute  ... his broken-down time`
   --> src/lib.rs:336:4
    /html[0]/body[1]/p[0] One element is missing: expected: `em`
WARNING: rendering difference in `Identifies the time zone that was used to compute  ... his broken-down time`
   --> src/lib.rs:336:4
    /html[0]/body[1]/p[0] One element is missing: expected: `0`
WARNING: rendering difference in `Returns the total number of whole microseconds in the duration,`
   --> src/duration.rs:197:4
    /html[0]/body[1]/p[0] Text differs:
        expected: `on overflow (exceeding 2^63 microseconds in either direction).`
        found:    `on overflow (exceeding 2`
WARNING: rendering difference in `Returns the total number of whole microseconds in the duration,`
   --> src/duration.rs:197:4
    /html[0]/body[1]/p[0] Unexpected element `sup`: found: `<sup>63</sup>`
WARNING: rendering difference in `Returns the total number of whole microseconds in the duration,`
   --> src/duration.rs:197:4
    /html[0]/body[1]/p[0] One element is missing: expected: ` microseconds in either direction).`
WARNING: rendering difference in `Returns the total number of whole nanoseconds in the duration,`
   --> src/duration.rs:205:4
    /html[0]/body[1]/p[0] Text differs:
        expected: `on overflow (exceeding 2^63 nanoseconds in either direction).`
        found:    `on overflow (exceeding 2`
WARNING: rendering difference in `Returns the total number of whole nanoseconds in the duration,`
   --> src/duration.rs:205:4
    /html[0]/body[1]/p[0] Unexpected element `sup`: found: `<sup>63</sup>`
WARNING: rendering difference in `Returns the total number of whole nanoseconds in the duration,`
   --> src/duration.rs:205:4
    /html[0]/body[1]/p[0] One element is missing: expected: ` nanoseconds in either direction).`
    Finished dev [unoptimized + debuginfo] target(s) in 0.52 secs
```