### PR TITLE
Explicitly mark get_precise_ns on OSX as inline.

### DIFF
--- a/benches/precise_time_ns.rs
+++ b/benches/precise_time_ns.rs
@@ -7,5 +7,8 @@ use test::Bencher;
 
 #[bench]
 fn bench_precise_time_ns(b: &mut Bencher) {
-    b.iter(|| time::precise_time_ns())
+    b.iter(|| {
+        time::precise_time_ns();
+        time::precise_time_ns();
+    });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ pub fn get_time() -> Timespec {
  * Returns the current value of a high-resolution performance counter
  * in nanoseconds since an unspecified epoch.
  */
+#[inline]
 pub fn precise_time_ns() -> u64 {
     sys::get_precise_ns()
 }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -348,6 +348,7 @@ mod inner {
             (tv.tv_sec as i64, tv.tv_usec * 1000)
         }
 
+        #[inline]
         pub fn get_precise_ns() -> u64 {
             unsafe {
                 let time = libc::mach_absolute_time();


### PR DESCRIPTION
Improve performance on OSX ~1.5-2x:

before 61 ns/iter (+/- 9)
after 43 ns/iter (+/- 11)

Not as visible benchmarking a single call but much more noticeable with many
calls.  For example for 10 calls it's:

before 328 ns/iter (+/- 54)
after 187 ns/iter (+/- 53)

Thus bump the benchamrk to do 2 calls to precise_time_ns.

Fixes #159 